### PR TITLE
prototype of post-processing cluster annotation

### DIFF
--- a/src/scllm/tl/chains.py
+++ b/src/scllm/tl/chains.py
@@ -2,8 +2,8 @@ from functools import partial
 
 from langchain_core.runnables.base import RunnableEach, RunnableLambda, RunnableParallel
 
-from .parser import construct_term_parser
-from .prompts import construct_term_prompt
+from .parser import construct_term_parser, construct_term_comparison_parser
+from .prompts import construct_term_prompt, construct_term_comparison_prompt
 
 
 def construct_passthrough(passthrough: list[str]):
@@ -34,6 +34,56 @@ def construct_term_chain(llm, term: str, extra: str = "", passthrough: list[str]
                 | llm
                 | parser
                 | RunnableLambda(lambda x: x.term),
+            }
+        )
+    )
+
+
+
+def construct_term_comparison_chain(llm, term: str, extra: str = "", passthrough: list[str] = []):
+    """
+    Constructs a chain for comparing two term descriptions using a language model.
+
+    This function sets up a chain where a language model evaluates whether two 
+    given descriptions of a term are the same. It uses a prompt template and an 
+    output parser to format the input and interpret the output, respectively. 
+    Additional data can be passed through the chain without modification.
+
+    Parameters
+    ----------
+    llm : BaseLanguageModel
+        The language model to use for term comparison.
+    term : str
+        The type of term to compare (e.g., "cell type").
+    extra : str, optional
+        Extra information to include in the prompt.
+    passthrough : list[str], optional
+        List of keys whose values should be passed through unchanged.
+
+    Returns
+    -------
+    RunnableEach
+        A chained runnable that performs the term comparison.
+    """
+
+    prompt = construct_term_comparison_prompt(term=term, extra=extra)
+    parser = construct_term_comparison_parser(term=term)
+    passes = construct_passthrough(passthrough)
+    format_instructions = parser.get_format_instructions()
+
+    return RunnableEach(
+        bound=RunnableParallel(
+            {
+                # "cluster": RunnableLambda(lambda x: x["cluster"]),
+                **passes,
+                "target": RunnableLambda(
+                    lambda x: prompt.format_prompt(
+                        entity1=x["entity1"], entity2=x["entity2"],format_instructions=format_instructions
+                    )
+                )
+                | llm
+                | parser
+                | RunnableLambda(lambda x: x.same),
             }
         )
     )

--- a/src/scllm/tl/cluster_annotation.py
+++ b/src/scllm/tl/cluster_annotation.py
@@ -1,8 +1,9 @@
 import pandas as pd
 import scanpy as sc
 from langchain_core.language_models import BaseLanguageModel
+from itertools import combinations
 
-from .chains import construct_term_chain
+from .chains import construct_term_chain, construct_term_comparison_chain
 from .utils import _prepare_mapping
 
 
@@ -23,6 +24,23 @@ def _prepare_chain_data(
         for i in range(num_samples):
             cluster_data.append({"cluster": group, "genes": genes, "init": i})
     return cluster_data
+
+def _prepare_pairwise_term_comparison(
+        term_mapping: dict[str, str], num_samples: int = 1
+):
+    data = []
+    for pair in combinations(term_mapping, 2):
+        for i in range(num_samples):
+            data.append({"index1": pair[0], "index2": pair[1],"entity1": term_mapping[pair[0]], "entity2": term_mapping[pair[1]], "init": i})
+
+    return data
+
+def _collapse_repeated_terms(comparison_df: pd.DataFrame, mapping: dict[str, str]):
+    result_df = comparison_df.groupby(['index1','index2']).mean()['target'].reset_index()
+    for index, row in result_df.iterrows():
+        if row['target'] > 0.5:
+            mapping[row['index2']] = mapping[row['index1']]
+    return mapping
 
 
 def annotate_cluster(
@@ -94,5 +112,13 @@ def annotate_cluster(
     # map cluster id's to celltype
     mapping = _prepare_mapping(df, "cluster", "target")
 
+    term_pairs = _prepare_pairwise_term_comparison(mapping, num_samples)
+
+    # compare the outputs of the LLM for identity using the LLM
+    chain2 = construct_term_comparison_chain(llm, term=term, extra=extra, passthrough=['index1', 'index2', 'init'])
+
+    pair_out = chain2.invoke(term_pairs)
+    df_pairs = pd.DataFrame(pair_out)
+    mapping = _collapse_repeated_terms(comparison_df=df_pairs, mapping=mapping)
     adata.obs[key_added] = adata.obs[cluster_key].astype(str).map(mapping)
     adata.uns[key_added] = out

--- a/src/scllm/tl/parser.py
+++ b/src/scllm/tl/parser.py
@@ -9,3 +9,15 @@ def construct_term_parser(term: str):
         term: str = Field(description=description)
 
     return PydanticOutputParser(pydantic_object=Term)
+
+
+
+def construct_term_comparison_parser(term: str):
+    description = f"Are the two {term}s the same."
+
+    class Same(BaseModel):
+        same: bool = Field(description=description)
+
+    return PydanticOutputParser(pydantic_object=Same)
+
+

--- a/src/scllm/tl/prompts.py
+++ b/src/scllm/tl/prompts.py
@@ -24,3 +24,25 @@ def construct_term_prompt(
             HumanMessagePromptTemplate.from_template(human_prompt),
         ]
     )
+
+
+
+def construct_term_comparison_prompt(
+    term: str = "cell type", 
+    extra: str = "",
+    system_prompt: str = "You are an expert biologist with extensive knowledge in single cell RNA-seq analysis.",
+    human_prompt: str = "Are the two {term} descriptions: {{entity1}} and {{entity2}} the same? \n{extra}",
+    format_instructions: bool = True,
+) -> ChatPromptTemplate:
+
+    human_prompt = human_prompt.format(term=term, extra=extra)
+
+    if format_instructions:
+        human_prompt = human_prompt + "\n{format_instructions}"
+
+    return ChatPromptTemplate.from_messages(
+        [
+            SystemMessagePromptTemplate.from_template(system_prompt),
+            HumanMessagePromptTemplate.from_template(human_prompt),
+        ]
+    )


### PR DESCRIPTION
This isn't quite ready to merge yet, @sagar87 can you please take a look?

This works in principle, but the parallel requests of all pairwise terms ends up hitting openai API limits. Maybe there is a more intelligent way of combining requests than doing all pairwise comparisons.

Also, pairwise comparisons is O(n^2), so this can get expensive as your number of clusters grows. 